### PR TITLE
Criando configuração com banco de dados em nuvem e adicionando certificado SSL

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -33,8 +33,8 @@ build/
 
 # Pastas do projeto
 public/
-
 js/
-
 styles/
 
+# Certificados
+certs/

--- a/config/database.js
+++ b/config/database.js
@@ -2,6 +2,8 @@
 import pkg from 'pg';
 // Importa o pacote 'dotenv' para carregar variáveis de ambiente de um arquivo .env
 import dotenv from 'dotenv';
+import { readFileSync } from 'fs';
+
 
 // Carrega as variáveis de ambiente do arquivo .env
 dotenv.config();
@@ -15,7 +17,11 @@ const banco = new Pool({
     host: process.env.DB_HOST, // Host do banco de dados (definido no .env)
     database: process.env.DB_NAME, // Nome do banco de dados (definido no .env)
     password: process.env.DB_PASSWORD, // Senha do banco de dados (definido no .env)
-    port: process.env.PORTA // Porta do banco de dados (definido no .env)
+    port: process.env.PORTA ,// Porta do banco de dados (definido no .env)
+    ssl: {
+        // Certificado SSL para conexões seguras
+        ca: readFileSync('./certs/global-bundle.pem').toString()
+    }
 });
 
 banco.connect()


### PR DESCRIPTION
…certificado SSL

Refiz a parte da conexão com banco de dados, migrando a conexão para um ambiente em nuvem(AWS).
Adicionei um certificado SSL para fazer conexão com o banco de dados em nuvem, sem o certificado a aplicação é barrada á fazer a conexão ao banco de dados na AWS. Alterei o .env adicionando as credenciais e alterei também o .gitignore para barrar o envio do certificado que está armazenando no caminho "/certs".